### PR TITLE
Implement add ticket types logic

### DIFF
--- a/MusicService/Services/EventService.cs
+++ b/MusicService/Services/EventService.cs
@@ -118,6 +118,11 @@ public class EventService
             throw new InvalidOperationException("You can only add ticketTypes to upcoming events");
         }
         
+        if (currentEvent.TicketTypes.Any(ticket => ticket.Name.ToLower().Trim() == ticketType.Name.ToLower().Trim()))
+        {
+            throw new InvalidOperationException("Ticket type already exists");
+        }
+        
         currentEvent.TicketTypes.Add(ticketType);
     }
     

--- a/MusicService/Services/EventService.cs
+++ b/MusicService/Services/EventService.cs
@@ -100,7 +100,26 @@ public class EventService
         
         eventById.Cancel();
     }
-    
+
+    public void AddTicketType(TicketType ticketType, Event currentEvent)
+    {
+        if (ticketType == null)
+        {
+            throw new ArgumentNullException(nameof(ticketType), "Ticket type cannot be empty");
+        }
+
+        if (currentEvent == null)
+        {
+            throw new ArgumentNullException(nameof(currentEvent), "Event cannot be empty");
+        }
+
+        if (currentEvent.Status != EventStatus.Upcoming)
+        {
+            throw new InvalidOperationException("You can only add ticketTypes to upcoming events");
+        }
+        
+        currentEvent.TicketTypes.Add(ticketType);
+    }
     
     public List <Event> GetUpcomingEvents()
     {


### PR DESCRIPTION
Closes #36 

## Summary
This PR adds functionality to attach ticket types to events through the service layer.

## Changes
- Added `AddTicketType(TicketType ticketType, Event currentEvent)` method
- Validates that:
  - `ticketType` is not null
  - `currentEvent` is not null
  - Event status is `Upcoming`
- Adds the ticket type to the event’s `TicketTypes` collection
