### PR TITLE
Add My Bookings view (#31)

### DIFF
--- a/MusicService/Program.cs
+++ b/MusicService/Program.cs
@@ -15,10 +15,10 @@ class Program
         
         var dataStorage = new DataStorage();
         var eventService = new EventService(dataStorage);
+        var bookingService = new BookingService(dataStorage);
         var registerService = new RegisterService(dataStorage);
         var loginService = new LoginService(dataStorage);
         var guestMenu = new GuestMenu(registerService, loginService);
-        /*var mainMenu = new MainMenu(eventService);*/
 
         registerService.Register("test", "test");
         var testUser = dataStorage.Users.FirstOrDefault(u => u.Username == "test");
@@ -50,14 +50,27 @@ class Program
         eventService.CreateFestival("Norwegian Wood", "Classic rock festival", EventCategory.Rock,
             DateTime.Now.AddDays(20), "Frognerparken, Oslo", testUser, tickets,
             new List<string> { "Ole Ivars", "Hobnobs" }, 2);
-        
-        
+
+        // seed a buyer with a few bookings so My Bookings has something to show
+        registerService.Register("buyer", "buyer");
+        var buyer = dataStorage.Users.FirstOrDefault(u => u.Username == "buyer");
+
+        var ironMaiden = dataStorage.Events.First(e => e.Title == "Iron Maiden Live");
+        var nordicNights = dataStorage.Events.First(e => e.Title == "Nordic Nights");
+        var oyafestivalen = dataStorage.Events.First(e => e.Title == "Øyafestivalen");
+
+        bookingService.CreateBooking(buyer, ironMaiden, ironMaiden.TicketTypes[1]);
+        bookingService.CreateBooking(buyer, nordicNights, nordicNights.TicketTypes[2]);
+        var toCancel = bookingService.CreateBooking(buyer, oyafestivalen, oyafestivalen.TicketTypes[0]);
+        bookingService.CancelBooking(toCancel, buyer);
+
+
         while (true)
         {
             User? loggedIn = guestMenu.ShowGuestMenu();
             if (loggedIn != null)
             {
-                var mainMenu = new MainMenu(eventService, loggedIn);
+                var mainMenu = new MainMenu(eventService, bookingService, loggedIn);
                 mainMenu.ShowMainMenu();
             }
         }

--- a/MusicService/UI/Menus/MainMenu.cs
+++ b/MusicService/UI/Menus/MainMenu.cs
@@ -9,19 +9,19 @@ namespace MusicService.UI.Menus;
 public class MainMenu
 {
     private readonly EventService _eventService;
-    /*
     private readonly BookingService _bookingService;
+    /*
     private readonly ReviewService _reviewService;
     */
     private readonly User _currentUser;
-    
 
-    public MainMenu(EventService eventService, /*BookingService bookingService, 
-        ReviewService reviewService*/ User currentUser)
+
+    public MainMenu(EventService eventService, BookingService bookingService,
+        /*ReviewService reviewService*/ User currentUser)
     {
         _eventService = eventService;
-        /*_bookingService = bookingService;
-        _reviewService = reviewService;*/
+        _bookingService = bookingService;
+        /*_reviewService = reviewService;*/
         _currentUser = currentUser;
     }
     public void ShowMainMenu()
@@ -46,8 +46,8 @@ public class MainMenu
                 case 2: SearchForEvents(); break;
                 case 3: CreateEvent(); break;
                 case 4: SeeMyEvents(); break;
-                case 5: SeeMyReviews(); break;
-                case 6: SeeMyBookings(); break;
+                case 5: SeeMyBookings(); break;
+                case 6: SeeMyReviews(); break;
                 case 7: return;
             }
         }
@@ -168,6 +168,7 @@ public class MainMenu
     }
     public void SeeMyBookings()
     {
-        //
+        var myBookingsMenu = new MyBookingsMenu(_bookingService, _currentUser);
+        myBookingsMenu.ShowMyBookingsMenu();
     }
 }

--- a/MusicService/UI/Menus/MyBookingsMenu.cs
+++ b/MusicService/UI/Menus/MyBookingsMenu.cs
@@ -1,0 +1,102 @@
+using MusicService.Enums;
+using MusicService.Models;
+using MusicService.Services;
+
+namespace MusicService.UI.Menus;
+
+public class MyBookingsMenu
+{
+    private readonly BookingService _bookingService;
+    private readonly User _currentUser;
+
+    public MyBookingsMenu(BookingService bookingService, User currentUser)
+    {
+        _bookingService = bookingService;
+        _currentUser = currentUser;
+    }
+
+    public void ShowMyBookingsMenu()
+    {
+        while (true)
+        {
+            Console.WriteLine();
+            Console.WriteLine("=== My Bookings ===");
+
+            var bookings = _bookingService.GetBookingsForUser(_currentUser);
+
+            if (bookings.Count == 0)
+            {
+                Console.WriteLine("You haven't booked any events yet.");
+                return;
+            }
+
+            // upcoming = confirmed bookings for events that haven't happened yet
+            var upcoming = bookings
+                .Where(b => b.Status == BookingStatus.Confirmed && b.Event.Date > DateTime.Now)
+                .ToList();
+
+            var past = bookings
+                .Where(b => b.Status == BookingStatus.Cancelled || b.Event.Date <= DateTime.Now)
+                .ToList();
+
+            Console.WriteLine("Upcoming:");
+            if (upcoming.Count == 0)
+            {
+                Console.WriteLine("  None");
+            }
+            for (int i = 0; i < upcoming.Count; i++)
+            {
+                Console.WriteLine($"  {i + 1}. {FormatBooking(upcoming[i])}");
+            }
+
+            if (past.Count > 0)
+            {
+                Console.WriteLine();
+                Console.WriteLine("Past:");
+                foreach (var b in past)
+                {
+                    Console.WriteLine($"   - {FormatBooking(b)}");
+                }
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("0. Go back");
+            if (upcoming.Count > 0)
+                Console.Write($"Select a booking to cancel (1-{upcoming.Count}) or 0 to go back: ");
+            else
+                Console.Write("Press 0 to go back: ");
+
+            int choice = ConsoleHelper.GetValidChoice(0, upcoming.Count);
+            if (choice == 0) return;
+
+            CancelBooking(upcoming[choice - 1]);
+        }
+    }
+
+    private string FormatBooking(Booking b)
+    {
+        return $"{b.Event.Title} | {b.TicketType.Name} | {b.PriceAtBooking} kr " +
+               $"| booked {b.DateBooked:dd MMM yyyy} | {b.BookingReference} | {b.Status}";
+    }
+
+    private void CancelBooking(Booking booking)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"Cancel booking {booking.BookingReference} for {booking.Event.Title}?");
+        Console.WriteLine("1. Yes");
+        Console.WriteLine("2. No");
+
+        int choice = ConsoleHelper.GetValidChoice(1, 2);
+        if (choice != 1) return;
+
+        try
+        {
+            _bookingService.CancelBooking(booking, _currentUser);
+            Console.WriteLine("Booking cancelled successfully.");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Could not cancel booking: {ex.Message}");
+        }
+    }
+}


### PR DESCRIPTION
Closes #31

Summary
- New `MyBookingsMenu` showing the user's bookings split into Upcoming and Past sections
- Each entry shows event title, ticket type, price paid, booking date, reference, status
- User can pick a confirmed upcoming booking to cancel (uses `BookingService.CancelBooking` from #30)
- Wired `BookingService` into `MainMenu` and fixed the swapped switch cases for "My Bookings" / "My reviews"
- Added a `buyer` test account with sample bookings in `Program.cs` so the view is easy to demo

How to test:
- Login as `buyer` / `buyer`, open My Bookings, verify Upcoming and Past sections
-  Cancel a confirmed booking and check it moves to Past with status `Cancelled`
- Login as `test` / `test` and confirm "no bookings" message